### PR TITLE
Fix: Update API paths to match current connector

### DIFF
--- a/issue-1-v2-api.md
+++ b/issue-1-v2-api.md
@@ -1,0 +1,49 @@
+# Issue 1: Add v2 API endpoints
+
+## Summary
+The webhook client library expects `/api/v1/*` paths but the connector currently serves at `/api/*`. We need to implement versioned API endpoints to support both current clients and future breaking changes.
+
+## Current State
+- Client code uses: `/api/v1/events`, `/api/v1/aggregates`, `/api/v1/subscribers`
+- Connector serves: `/api/events`, `/api/aggregates`, `/api/subscribers`
+- Result: 404 errors when using the client library
+
+## Proposed Solution
+
+### Option 1: Add v1 prefix to current endpoints (backwards compatible)
+```typescript
+// Keep existing paths working
+app.get('/api/events', handler);          // Legacy
+app.get('/api/v1/events', handler);        // New (same handler)
+
+// Future v2 can coexist
+app.get('/api/v2/events', newHandler);
+```
+
+### Option 2: Redirect /api/v1 to current implementation
+```typescript
+app.use('/api/v1', apiRouter);  // Points to current /api/*
+```
+
+### Option 3: Make v1 the default, keep legacy for migration
+```typescript
+app.use('/api/v1', apiRouter);     // Primary
+app.use('/api', apiRouter);        // Deprecated, warn in logs
+```
+
+## Affected Endpoints
+- `/api/events` → `/api/v1/events`
+- `/api/aggregates` → `/api/v1/aggregates`
+- `/api/subscribers` → `/api/v1/subscribers`
+- `/api/enrichment/:id` → `/api/v1/enrichment/:id`
+
+## Testing
+- Verify client library connects successfully
+- Ensure backwards compatibility for existing integrations
+- Add versioning headers: `X-API-Version: 1.0`
+
+## Priority
+**High** - Blocking client adoption
+
+## Labels
+enhancement, api, versioning

--- a/issue-2-aggregates-html.md
+++ b/issue-2-aggregates-html.md
@@ -1,0 +1,49 @@
+# Issue 2: Fix aggregates endpoint returning HTML
+
+## Summary
+The `/api/aggregates` endpoint returns HTML (the frontend app) instead of JSON, making it unusable for API clients.
+
+## Current Behavior
+```bash
+$ curl -H "Authorization: Bearer $API_KEY" https://webhook.alteriom.net/api/aggregates
+<!doctype html>
+<html lang="en">
+...
+```
+
+## Expected Behavior
+```json
+{
+  "aggregates": [...],
+  "total": 123,
+  "limit": 20,
+  "offset": 0
+}
+```
+
+## Root Cause
+Likely routing issue where `/api/aggregates` is falling through to the frontend catch-all route instead of hitting the API handler.
+
+## Reproduction
+```javascript
+const res = await fetch('https://webhook.alteriom.net/api/aggregates', {
+  headers: { 'Authorization': 'Bearer YOUR_API_KEY' }
+});
+const data = await res.json(); // Error: Unexpected token '<'
+```
+
+## Investigation Needed
+1. Check Express/Fastify route order (API routes must come before `app.use('*', frontend)`)
+2. Verify aggregates route is registered: `app.get('/api/aggregates', handler)`
+3. Check if path is missing from router exports
+
+## Impact
+- **Severity**: High
+- **Affected**: All API clients trying to list aggregates
+- **Workaround**: None currently
+
+## Priority
+**Critical** - Core API endpoint non-functional
+
+## Labels
+bug, api, routing

--- a/issue-3-client-paths.md
+++ b/issue-3-client-paths.md
@@ -1,0 +1,69 @@
+# Issue 3: Update client library to match current API paths
+
+## Summary
+The `@alteriom/webhook-client` package uses incorrect API paths (`/api/v1/*`) that don't match the deployed connector (`/api/*`).
+
+## Current State
+**Client code:**
+```typescript
+// src/api-client.ts
+const eventsUrl = `${baseURL}/api/v1/events`;  // 404
+const aggregatesUrl = `${baseURL}/api/v1/aggregates`;  // 404
+```
+
+**Actual API:**
+- ✅ Working: `/api/events`, `/api/subscribers`
+- ❌ Broken: `/api/aggregates` (returns HTML - see issue #2)
+
+## Proposed Fix
+
+### Short-term: Update client to use current paths
+```typescript
+// src/api-client.ts
+- const eventsUrl = `${baseURL}/api/v1/events`;
++ const eventsUrl = `${baseURL}/api/events`;
+```
+
+### Long-term: Support version negotiation
+```typescript
+constructor(config: {
+  baseURL: string;
+  apiKey: string;
+  apiVersion?: 'v1' | 'v2';  // Default: detect from /api/version
+}) {
+  this.apiVersion = config.apiVersion || await this.detectVersion();
+  this.basePath = `/api${this.apiVersion ? '/' + this.apiVersion : ''}`;
+}
+```
+
+## Files to Update
+- `src/api-client.ts` - Main API client paths
+- `src/resources/events.ts` - Events endpoint
+- `src/resources/aggregates.ts` - Aggregates endpoint
+- `src/resources/enrichment.ts` - Enrichment endpoint
+- `src/resources/subscribers.ts` - Subscribers endpoint
+- `tests/**/*.test.ts` - Update test URLs
+- `README.md` - Update examples
+
+## Testing Checklist
+- [ ] `npm test` passes
+- [ ] Integration test against live API
+- [ ] Examples in README work
+- [ ] TypeScript types still match responses
+
+## Migration Notes
+If we add v1 routing on the connector side (issue #1), we can support both:
+```typescript
+// Auto-detect and prefer versioned endpoint
+const version = await fetch(`${baseURL}/api/version`).then(r => r.json());
+this.apiPath = version.current ? `/api/${version.current}` : '/api';
+```
+
+## Priority
+**High** - Blocking client adoption
+
+## Related Issues
+- #1 (Add v2 API endpoints) - Coordinate path changes
+
+## Labels
+bug, client, breaking-change

--- a/src/client.ts
+++ b/src/client.ts
@@ -239,7 +239,7 @@ export class AlteriomWebhookClient {
     list: async (params?: EventListParams): Promise<PaginatedResponse<WebhookEvent>> => {
       await this.rateLimiter.acquire();
       return this.retryLogic.execute(async () => {
-        const { data } = await this.http.get('/api/v1/events', { params });
+        const { data } = await this.http.get('/api/events', { params });
         return {
           data: data.events,
           total: data.total,
@@ -256,7 +256,7 @@ export class AlteriomWebhookClient {
     get: async (id: string): Promise<WebhookEvent> => {
       await this.rateLimiter.acquire();
       return this.retryLogic.execute(async () => {
-        const { data } = await this.http.get(`/api/v1/events/${id}`);
+        const { data } = await this.http.get(`/api/events/${id}`);
         return data;
       });
     },
@@ -272,7 +272,7 @@ export class AlteriomWebhookClient {
     list: async (params?: { page?: number; limit?: number }): Promise<PaginatedResponse<EventAggregate>> => {
       await this.rateLimiter.acquire();
       return this.retryLogic.execute(async () => {
-        const { data } = await this.http.get('/api/v1/aggregates', { params });
+        const { data } = await this.http.get('/api/aggregates', { params });
         return {
           data: data.aggregates,
           total: data.total,
@@ -289,7 +289,7 @@ export class AlteriomWebhookClient {
     get: async (id: string): Promise<EventAggregate> => {
       await this.rateLimiter.acquire();
       return this.retryLogic.execute(async () => {
-        const { data } = await this.http.get(`/api/v1/aggregates/${id}`);
+        const { data } = await this.http.get(`/api/aggregates/${id}`);
         return data;
       });
     },
@@ -305,7 +305,7 @@ export class AlteriomWebhookClient {
     enrich: async (aggregateId: string): Promise<Enrichment> => {
       await this.rateLimiter.acquire();
       return this.retryLogic.execute(async () => {
-        const { data} = await this.http.post(`/api/v1/aggregates/${aggregateId}/enrich`);
+        const { data} = await this.http.post(`/api/aggregates/${aggregateId}/enrich`);
         return data;
       });
     },
@@ -321,7 +321,7 @@ export class AlteriomWebhookClient {
     list: async (params?: { page?: number; limit?: number }): Promise<PaginatedResponse<Delivery>> => {
       await this.rateLimiter.acquire();
       return this.retryLogic.execute(async () => {
-        const { data } = await this.http.get('/api/v1/deliveries', { params });
+        const { data } = await this.http.get('/api/deliveries', { params });
         return {
           data: data.deliveries,
           total: data.total,

--- a/test-jarvis.ts
+++ b/test-jarvis.ts
@@ -1,0 +1,99 @@
+#!/usr/bin/env ts-node
+/**
+ * Test script for Jarvis webhook client
+ * Tests connection to webhook.alteriom.net using Jarvis API key
+ */
+
+import { AlteriomWebhookClient } from './dist/index.js';
+
+// Jarvis credentials (from MEMORY.md)
+const JARVIS_API_KEY = 'fc014099527a42b395f349760f74c07f083231d294192f35a3537c5ef256c23c';
+const JARVIS_SUBSCRIBER_ID = '0d225333-9b98-407e-a547-9d42af215b47';
+
+async function main() {
+  console.log('🧪 Testing Alteriom Webhook Client for Jarvis');
+  console.log('==============================================\n');
+
+  // Initialize client
+  const client = new AlteriomWebhookClient({
+    baseURL: 'https://webhook.alteriom.net',
+    apiKey: JARVIS_API_KEY,
+    timeout: 30000,
+  });
+
+  console.log('✅ Client initialized');
+  console.log(`   Base URL: https://webhook.alteriom.net`);
+  console.log(`   API Key: ${JARVIS_API_KEY.slice(0, 16)}...`);
+  console.log(`   Subscriber ID: ${JARVIS_SUBSCRIBER_ID}\n`);
+
+  try {
+    // Test 1: List subscribers
+    console.log('📋 Test 1: List subscribers');
+    const subscribers = await client.subscribers.list();
+    console.log(`   Found ${subscribers.length} subscriber(s)`);
+    
+    const jarvisSub = subscribers.find(s => s.id === JARVIS_SUBSCRIBER_ID);
+    if (jarvisSub) {
+      console.log(`   ✅ Jarvis subscription found: ${jarvisSub.name}`);
+      console.log(`      URL: ${jarvisSub.url}`);
+      console.log(`      Events: ${jarvisSub.events.join(', ')}`);
+      console.log(`      Enabled: ${jarvisSub.enabled}`);
+    } else {
+      console.log('   ⚠️  Jarvis subscription not found');
+    }
+    console.log();
+
+    // Test 2: List recent events
+    console.log('📋 Test 2: List recent events');
+    const events = await client.events.list({
+      limit: 10,
+      event_type: 'workflow_run',
+    });
+    console.log(`   Found ${events.total} workflow_run events`);
+    console.log(`   Showing ${events.data.length} most recent:\n`);
+    
+    for (const event of events.data.slice(0, 5)) {
+      const payload = event.payload as any;
+      const repo = payload?.repository?.name || 'unknown';
+      const action = payload?.action || 'unknown';
+      const conclusion = payload?.workflow_run?.conclusion || 'pending';
+      console.log(`   - ${event.event_type}.${action} on ${repo} (${conclusion})`);
+      console.log(`     ${new Date(event.received_at).toLocaleString()}`);
+    }
+    console.log();
+
+    // Test 3: Get aggregates (if any)
+    console.log('📋 Test 3: List aggregates');
+    const aggregates = await client.aggregates.list({ limit: 5 });
+    console.log(`   Found ${aggregates.total} aggregate(s)`);
+    
+    if (aggregates.data.length > 0) {
+      const latest = aggregates.data[0];
+      console.log(`   Latest aggregate: ${latest.id}`);
+      console.log(`      Events: ${latest.event_count}`);
+      console.log(`      Repository: ${latest.repository || 'N/A'}`);
+      
+      if (latest.enrichment) {
+        console.log(`      ✨ Has enrichment!`);
+        console.log(`         Risk: ${latest.enrichment.risk_level}`);
+        console.log(`         Summary: ${latest.enrichment.summary?.slice(0, 80)}...`);
+      }
+    }
+    console.log();
+
+    console.log('✅ All tests passed!');
+    console.log('🎉 Webhook client is working correctly\n');
+
+  } catch (error: any) {
+    console.error('❌ Test failed:', error.message);
+    if (error.status) {
+      console.error(`   HTTP Status: ${error.status}`);
+    }
+    if (error.details) {
+      console.error(`   Details:`, error.details);
+    }
+    process.exit(1);
+  }
+}
+
+main().catch(console.error);

--- a/test-simple.js
+++ b/test-simple.js
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+/**
+ * Simple test using raw fetch to verify Jarvis webhook credentials
+ */
+
+const JARVIS_API_KEY = 'fc014099527a42b395f349760f74c07f083231d294192f35a3537c5ef256c23c';
+const JARVIS_SUBSCRIBER_ID = 'f57063a7-1fb4-44f8-98fc-58396db662bb';
+const BASE_URL = 'https://webhook.alteriom.net';
+
+async function test() {
+  console.log('🧪 Testing Jarvis Webhook API Access\n');
+
+  try {
+    // Test 1: List subscribers
+    console.log('📋 Test 1: GET /api/subscribers');
+    const subsRes = await fetch(`${BASE_URL}/api/subscribers`, {
+      headers: { 'Authorization': `Bearer ${JARVIS_API_KEY}` }
+    });
+    const subs = await subsRes.json();
+    console.log(`   Status: ${subsRes.status}`);
+    console.log(`   Found ${subs.length} subscribers`);
+    
+    const jarvisSub = subs.find(s => s.id === JARVIS_SUBSCRIBER_ID);
+    if (jarvisSub) {
+      console.log(`   ✅ Jarvis found: ${jarvisSub.name}`);
+      console.log(`      Events: ${jarvisSub.events.join(', ')}`);
+    } else {
+      console.log('   ⚠️  Jarvis subscriber not found');
+      console.log(`      Available IDs: ${subs.map(s => `${s.name}(${s.id.slice(0,8)})`).join(', ')}`);
+    }
+    console.log();
+
+    // Test 2: List events
+    console.log('📋 Test 2: GET /api/events?limit=5');
+    const eventsRes = await fetch(`${BASE_URL}/api/events?limit=5`, {
+      headers: { 'Authorization': `Bearer ${JARVIS_API_KEY}` }
+    });
+    const eventsData = await eventsRes.json();
+    console.log(`   Status: ${eventsRes.status}`);
+    console.log(`   Total events: ${eventsData.total}`);
+    console.log(`   Showing ${eventsData.events.length} most recent:\n`);
+    
+    for (const event of eventsData.events) {
+      const repo = event.repository || 'unknown';
+      const action = event.action || 'unknown';
+      console.log(`   - ${event.event_type}.${action} on ${repo}`);
+      console.log(`     ${new Date(event.received_at).toLocaleString()}`);
+    }
+    console.log();
+
+    // Test 3: List aggregates
+    console.log('📋 Test 3: GET /api/aggregates?limit=3');
+    const aggsRes = await fetch(`${BASE_URL}/api/aggregates?limit=3`, {
+      headers: { 'Authorization': `Bearer ${JARVIS_API_KEY}` }
+    });
+    const aggsData = await aggsRes.json();
+    console.log(`   Status: ${aggsRes.status}`);
+    console.log(`   Total: ${aggsData.total}`);
+    console.log(`   Recent aggregates:\n`);
+    
+    for (const agg of aggsData.aggregates || []) {
+      console.log(`   - ${agg.id.slice(0, 8)}... (${agg.event_count} events)`);
+      console.log(`     Repo: ${agg.repository || 'N/A'}`);
+      if (agg.enrichment) {
+        console.log(`     ✨ Enriched: ${agg.enrichment.risk_level} risk`);
+      }
+    }
+    console.log();
+
+    console.log('✅ All tests passed!');
+    console.log('🎉 Jarvis API credentials working\n');
+
+  } catch (error) {
+    console.error('❌ Test failed:', error.message);
+    process.exit(1);
+  }
+}
+
+test();


### PR DESCRIPTION
## Summary
Removes `/v1/` prefix from all API endpoints to match the deployed connector.

## Changes
- ✅ Events: `/api/v1/events` → `/api/events`
- ✅ Aggregates: `/api/v1/aggregates` → `/api/aggregates`
- ✅ Enrichment: `/api/v1/aggregates/:id/enrich` → `/api/aggregates/:id/enrich`
- ✅ Deliveries: `/api/v1/deliveries` → `/api/deliveries`
- ✅ Subscribers: Already correct (`/api/subscribers`)

## Testing
Tested against live API (`webhook.alteriom.net`):
- ✅ Events endpoint working (9,002 events)
- ✅ Subscribers endpoint working (3 subscribers)
- ⚠️ Aggregates returns HTML (connector bug, separate issue)

## Related Issues
- See `issue-1-v2-api.md` - Connector should add v1 routing
- See `issue-2-aggregates-html.md` - Aggregates endpoint broken
- See `issue-3-client-paths.md` - Documentation of this fix

## Breaking Change
⚠️ Clients using this package will need to rebuild after upgrade.